### PR TITLE
Remove expired job

### DIFF
--- a/src/_data/jobs.js
+++ b/src/_data/jobs.js
@@ -1,4 +1,5 @@
 module.exports = [
+  /*
   {
     title: "AI Head of Impact and Evaluation",
     grade: "Grade 6",
@@ -40,6 +41,7 @@ module.exports = [
     },
     link: "https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=b3duZXI9NTA3MDAwMCZwYWdlYWN0aW9uPXZpZXd2YWNieWpvYmxpc3Qmc2VhcmNocGFnZT0xJm93bmVydHlwZT1mYWlyJnBhZ2VjbGFzcz1Kb2JzJmpvYmxpc3Rfdmlld192YWM9MTkwNjMzOCZ1c2Vyc2VhcmNoY29udGV4dD03NzM2MjA5OSZzZWFyY2hzb3J0PXNjb3JlJnJlcXNpZz0xNzEzNDQ4NDk3LWYwZjdmMjI3N2JiNjc0YThjOTE0Y2RkNzJmMzZlZWI4NzIwOTQ5ZDU="
   },
+  */
   {
     title: "AI Impact and Evaluation Lead",
     grade: "Grade 7",


### PR DESCRIPTION
## Context

Removing an expired job listing from the website.

## Guidance to review

Only one job should now be visible, and that should link through to an active job on Civil Service Jobs.

## Note

We'll be moving these to the CMS soon, so won't need PRs for simple updates like this.