### PR TITLE
Add new job to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 _site
 /test-results/
 .DS_Store
+/playwright-report

--- a/src/_data/jobs.js
+++ b/src/_data/jobs.js
@@ -1,41 +1,5 @@
 module.exports = [
   {
-    title: "AI Impact and Evaluation Lead",
-    grade: "Grade 7",
-    salary: "£53,400 - £66,875",
-    location: "Bristol, Glasgow, London, Manchester, York",
-    headline: "i.AI’s Impact and Evaluation team will support i.AI in their mission to identify and deploy AI for the public good, by building their work into each stage of product development, from scoping, to incubation, and onwards to scaling. Team members will embed into product development teams, designing and delivering of randomised control trials, impact evaluations, and qualitative studies primarily into the efficiency and quality impacts of our AI products.",
-    description: {
-      about: [
-        `The Incubator for Artificial Intelligence (i.AI) leads the Cabinet Office AI for Public Good programme to harness the opportunities presented by AI to improve the lives of citizens. It focuses on a number of priority projects in home affairs, health, education and government efficiency projects. The i.AI team uses ethical and secure methods at all times to help deliver better public services.`,
-        `Building on the work of No10 Data Science Team (10DS) and other leading technology teams across the civil service, i.AI will experiment and prove what is possible in improving the use of AI across the government. It was recently announced that i.AI will expand a further 40 roles to build a scale up function, which will take successful incubated projects into production.`,
-        `i.AI’s <strong>Impact and Evaluation</strong> team will build their work into each stage of product development, from scoping, to incubation, and onwards to scaling. Team members will embed into product development teams, designing and delivering of randomised control trials, impact evaluations, and qualitative studies primarily into the efficiency and quality impacts of our AI products.`
-      ],
-      responsibilities: [
-        `Embedding impact and evaluation into products from the very start and throughout the development cycle.`,
-        `We will teach you to apply your skills to deliver wider AI evaluation throughout the development cycle. These are new and emerging methods that you would be key in forging practical delivery of: safety assessment, algorithmic transparency reporting, red teaming to assess AI bias and safety.`,
-        `Building evidence-led and data-driven cases for i.AI funding bids in processes such as Budgets or Spending Reviews.`,
-        `Conducting data analysis, drawing insights and recommendations and presenting them stakeholders.`
-      ],
-      skills: [
-        `Experience of designing, leading and delivering research, from a relevant discipline such as an economist, behavioural scientist, or a social scientist.`,
-        `Excellent analytical and critical thinking skills, with the ability to synthesise complex information and draw insights from data.`,
-        `Ability to engage and influence others at various levels of seniority to maximise the impact of research studies.`,
-        `Knowledge of either quantitative and/or qualitative research design, methods and analysis.`,
-        `Ability to work collaboratively and across disciplines, and maintain strong working relationships with a broad range of individuals.`,
-        `Ability to communicate research for varied audiences, using different media/formats e.g. technical reports; presentations; web-based tools.`,
-        `Non-essential but beneficial: experience of leading on cost-benefit analysis and policy appraisal in line with the Green Book.`,
-        `Needs to be/become DDAT/badged Economist/Social Researcher/Statistician/Operational Researcher.`,
-        `In-depth expertise of a number of commonly used evaluation methods.`,
-        `Experimental and quasi-experimental methods are particularly desirable.`,
-        `Excellent communication skills, both verbal and written, with the ability to communicate technical information on evaluations to non-specialists in ways that are easily understood.`,
-        `Strong ability to articulate the value of evaluating products to a broad range of stakeholders.`,
-        `Coding ability in python or similar languages are not essential but would be beneficial.`
-      ]
-    },
-    link: "https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=c2VhcmNocGFnZT0xJm93bmVydHlwZT1mYWlyJnBhZ2VjbGFzcz1Kb2JzJmpvYmxpc3Rfdmlld192YWM9MTkwNjQzOCZvd25lcj01MDcwMDAwJnBhZ2VhY3Rpb249dmlld3ZhY2J5am9ibGlzdCZzZWFyY2hzb3J0PXNjb3JlJnVzZXJzZWFyY2hjb250ZXh0PTc3MzYyMDk5JnJlcXNpZz0xNzEzNDQ4NDk3LWYwZjdmMjI3N2JiNjc0YThjOTE0Y2RkNzJmMzZlZWI4NzIwOTQ5ZDU="
-  },
-  {
     title: "Deputy Director, i.AI Strategy and Business Engagement",
     grade: "SCS 1",
     salary: "£75,000 - £117,800",

--- a/src/_data/jobs.js
+++ b/src/_data/jobs.js
@@ -1,53 +1,10 @@
 module.exports = [
-  /*
-  {
-    title: "AI Head of Impact and Evaluation",
-    grade: "Grade 6",
-    salary: "£64,700 - £79,073",
-    location: "Bristol, Glasgow, London, Manchester, York",
-    headline: "",
-    description: {
-      about: [
-        `The Incubator for Artificial Intelligence (i.AI) - is an AI for public good programme to harness the opportunities presented by AI to improve the lives of citizens. It focuses on a number of priority projects in home affairs, health, education and government efficiency projects. The i.AI team uses ethical and secure methods at all times to help deliver better public services.`,
-        `Building on the work of No10 Data Science Team (10DS) and other leading technology teams across the civil service, i.AI will experiment and prove what is possible in improving the use of AI across the government. It was recently announced that i.AI will expand a further 40 roles to build a scale up function, which will take successful incubated projects into production.`,
-        `i.AI’s <strong>Impact and Evaluation</strong> team will build their work into each stage of product development, from scoping, to incubation, and onwards to scaling. Team members will embed into product development teams, designing and delivering of randomised control trials, impact evaluations, and qualitative studies primarily into the efficiency and quality impacts of our AI products.`
-      ],
-      responsibilities: [
-        `Setting up and leading i.AI’s Impact and Evaluation function.`,
-        `Leading the design and implementation of evaluations for our AI products, including developing evaluation frameworks, identifying appropriate methodologies, and collecting and analysing data.`,
-        `Communicating the results of your team’s evaluations in a way that is engaging and supports delivery of the mission of i.AI managing and mentoring Impact and Evaluation Leads (3FTE), providing guidance and support to ensure high-quality work.`,
-        `Embedding impact and evaluation into AI products from the very start and throughout the development cycle.`,
-        `Leading the team to deliver wider AI evaluation throughout the development cycle. Experience in this is not required, as these are new and emerging methods that you would be key in forging practical delivery of: safety assessment, algorithmic transparency reporting, red teaming to assess AI bias and safety.`,
-        `Building evidence led and data driven cases for i.AI funding bids in processes such as Budgets or Spending Reviews.`,
-        `Developing data collection tools, such as surveys, interviews, and focus groups, and ensuring data quality.`,
-        `Conducting data analysis, drawing insights and recommendations and presenting them stakeholders.`
-      ],
-      skills: [
-        `Excellent analytical and critical thinking skills, with the ability to synthesise complex information and draw insights from data.`,
-        `Experience of leading, overseeing and motivating researchers to deliver high impact research and of managing its technical direction.`,
-        `Experience of leading on cost-benefit analysis and policy appraisal in line with the Green Book.`,
-        `Experience of designing, leading and delivering research, from a relevant discipline such as an economist, behavioural scientist, or a social scientist.`,
-        `Ability to engage and influence others at various levels of seniority to maximise the impact of research studies.`,
-        `Considerable knowledge of qualitative and quantitative research design, methods and analysis.`,
-        `Ability to work collaboratively and across disciplines, and maintain strong working relationships with a broad range of individuals.`,
-        `Ability to communicate research for varied audiences, using different media/formats e.g. technical reports; presentations; web-based tools.`,
-        `You need to be, or will be willing to become badged in one of the following professions: economist, social researcher, statistician, operational researcher, or be part of the DDAT profession.`,
-        `In-depth expertise of a number of commonly used evaluation methods.`,
-        `Experimental and quasi-experimental methods are particularly desirable.`,
-        `Excellent communication skills, both verbal and written, with the ability to communicate technical information on evaluations to non-specialists in ways that are easily understood.`,
-        `Strong ability to articulate the value of evaluating products to a broad range of stakeholders.`,
-        `Coding ability in python or similar languages would be beneficial.`
-      ]
-    },
-    link: "https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=b3duZXI9NTA3MDAwMCZwYWdlYWN0aW9uPXZpZXd2YWNieWpvYmxpc3Qmc2VhcmNocGFnZT0xJm93bmVydHlwZT1mYWlyJnBhZ2VjbGFzcz1Kb2JzJmpvYmxpc3Rfdmlld192YWM9MTkwNjMzOCZ1c2Vyc2VhcmNoY29udGV4dD03NzM2MjA5OSZzZWFyY2hzb3J0PXNjb3JlJnJlcXNpZz0xNzEzNDQ4NDk3LWYwZjdmMjI3N2JiNjc0YThjOTE0Y2RkNzJmMzZlZWI4NzIwOTQ5ZDU="
-  },
-  */
   {
     title: "AI Impact and Evaluation Lead",
     grade: "Grade 7",
     salary: "£53,400 - £66,875",
     location: "Bristol, Glasgow, London, Manchester, York",
-    headline: "",
+    headline: "i.AI’s Impact and Evaluation team will support i.AI in their mission to identify and deploy AI for the public good, by building their work into each stage of product development, from scoping, to incubation, and onwards to scaling. Team members will embed into product development teams, designing and delivering of randomised control trials, impact evaluations, and qualitative studies primarily into the efficiency and quality impacts of our AI products.",
     description: {
       about: [
         `The Incubator for Artificial Intelligence (i.AI) leads the Cabinet Office AI for Public Good programme to harness the opportunities presented by AI to improve the lives of citizens. It focuses on a number of priority projects in home affairs, health, education and government efficiency projects. The i.AI team uses ethical and secure methods at all times to help deliver better public services.`,
@@ -77,5 +34,36 @@ module.exports = [
       ]
     },
     link: "https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=c2VhcmNocGFnZT0xJm93bmVydHlwZT1mYWlyJnBhZ2VjbGFzcz1Kb2JzJmpvYmxpc3Rfdmlld192YWM9MTkwNjQzOCZvd25lcj01MDcwMDAwJnBhZ2VhY3Rpb249dmlld3ZhY2J5am9ibGlzdCZzZWFyY2hzb3J0PXNjb3JlJnVzZXJzZWFyY2hjb250ZXh0PTc3MzYyMDk5JnJlcXNpZz0xNzEzNDQ4NDk3LWYwZjdmMjI3N2JiNjc0YThjOTE0Y2RkNzJmMzZlZWI4NzIwOTQ5ZDU="
-  }
+  },
+  {
+    title: "Deputy Director, i.AI Strategy and Business Engagement",
+    grade: "SCS 1",
+    salary: "£75,000 - £117,800",
+    location: "London",
+    headline: "We are recruiting for Deputy Director i.AI Strategy and Business Engagement, to support i.AI in their mission to identify and deploy AI for the public good. This role will support that mission by working across government, and representing the Cabinet Office externally, to ensure that i.AI is effectively joined up with the thriving UK AI ecosystem.",
+    description: {
+      about: [
+        `This is an exciting opportunity to join a brand new team operating at the heart of government. The incubator for Artificial Intelligence (i.AI) is a brilliant new team, comprised of technical experts who are set up to harness the opportunity of AI to improve lives, generate efficiency savings and deliver better public services.`,
+        `This role is a critical one, sitting at the heart of our structure and overseeing the key enabling functions for our team - Strategy, Operations and Impact. You will work closely with technical experts from across the Digital Data and Technology (DDaT) profession, including AI Engineers, Data Scientists, Software Developers, User Researchers and more. These technical roles form part of our product teams, who are building tools for i.AI to deploy across government.`,
+        `This role will have line management responsibility for three teams, covering <strong>strategy, business operations, and impact and evaluation</strong>. Taken together, these functions will provide support to our product team and make sure that we are able to interface effectively with the rest of government in delivering our mission.`
+      ],
+      responsibilities: [
+        `You will constructively engage across government, building effective working relationships, and engaging with senior stakeholders to champion AI and data driven solutions.`,
+        `You will demonstrate a strong ability to form effective collaborations and manage very senior stakeholders, while leading by example for analysts, technical staff, and policy teams across government to inspire a step change in innovation practice use and technical upskilling.`,
+        `You will be credible externally in discussing AI for the public good and setting a vision for the UK’s adoption of this exciting technology, including effective engagement with Government AI ministers, and meeting regularly with business leaders and representing the UK government position.`,
+        `You will manage three critical branches in the team covering strategy, business operations, and impact and evaluation.`,
+        `You will report to Dr Laura Gilbert (10 Downing Street), Director of i.AI and Senior Responsible Officer (SRO) of AI for the Public Good and work very closely with ministerial offices to ensure strategic alignment.`
+      ],
+      skills: [
+        `Proven experience of operating effectively in a relevant tech-adjacent field, for example experience in both AI strategy and implementation, wider digital/analysis functions in government or a large, complex tech-focussed organisation.`,
+        `Evidenced ability to build and maintain relationships with, and secure the confidence and trust of stakeholders, senior leaders, and peers, through the provision of expert advice on strategy, partnership working, and collaborative project delivery.`,
+        `Ability to work at pace, handling competing priorities and challenging deadlines in complex stakeholder environments. Rapid, collaborative problem solving and resolving complex issues when they arise.`,
+        `Excellent communication and written skills, with a proven track record of influencing effectively at Ministerial and Permanent Secretary level; or Board Level.`,
+        `Experience as a confident and empowering leader who sets a clear strategic direction to deliver key priorities through teams, with a track record of motivating, developing and successfully leading diverse, high-performing teams.`,
+        `Experience of setting up new teams, establishing good ways of working and effective partnership models.`,
+        `Experience of working with external business partners/collaborators to drive change within large, complex organisations and with stakeholders relevant to the mission of i.AI.`
+      ]
+    },
+    link: "https://www.civilservicejobs.service.gov.uk/csr/jobs.cgi?jcode=1908736"
+  },
 ];

--- a/src/join.njk
+++ b/src/join.njk
@@ -51,7 +51,7 @@ templateEngineOverride: njk
                     <h2 class="text-[18px] font-semibold pb-0">{{ job.title | safe }} ({{ job.grade }})</h2>
                     <p class="mt-2 text-[13px] font-semibold text-slate-600">{{ job.location }} &#8226; {{ job.salary }}</p>
                     {% if job.headline %}
-                        <p class="text-[18px] text-slate-800 font-light mb-2">{{ job.headline }}</p>
+                        <p class="mt-2 text-[16px] text-slate-800 font-light mb-2">{{ job.headline }}</p>
                     {% endif %}
                     <div class="-mt-2">
                         <a href="/jobs/{{ job.title | slugify }}/" class="iai-button iai-button--pink">{{job.title}}<span> &#8594;</span></a>

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -7,7 +7,6 @@ const pagesToTest = [
   'about',
   'join',
   'jobs/deputy-director-i-ai-strategy-and-business-engagement/',
-  'jobs/ai-impact-and-evaluation-lead',
   'projects',
   'projects/consultations',
   'projects/redbox-copilot',

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -6,7 +6,7 @@ const pagesToTest = [
   '',
   'about',
   'join',
-  'jobs/ai-head-of-impact-and-evaluation/',
+  'jobs/deputy-director-i-ai-strategy-and-business-engagement/',
   'jobs/ai-impact-and-evaluation-lead',
   'projects',
   'projects/consultations',


### PR DESCRIPTION
## Context

* Add the new `Deputy Director, i.AI Strategy and Business Engagement` role to the website
* Remove expired AI Head of Impact and Evaluation role

## Guidance to review

Visit the `/join` page and check the jobs links and content works and looks okay.
