### PR TITLE
Add FAQs to CMS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const htmlmin = require("html-minifier");
 const CleanCSS = require("clean-css");
 const fs = require('fs');
+const { documentToHtmlString } = require('@contentful/rich-text-html-renderer');
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
@@ -18,6 +19,10 @@ module.exports = function (eleventyConfig) {
     }
 
     return content;
+  });
+
+  eleventyConfig.addFilter("richTextToHTML", (value) => {
+    return documentToHtmlString(value);
   });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@contentful/rich-text-html-renderer": "^16.5.2",
         "@tailwindcss/typography": "^0.5.10",
         "clean-css": "^5.3.2",
         "contentful": "^10.8.9",
@@ -214,10 +215,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@contentful/rich-text-html-renderer": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-16.5.2.tgz",
+      "integrity": "sha512-OHdVZbkRdHbl0pLNhSyUUIhRQGWIhuYaoQkkt2tKayHE+lB2ID4lJwYAl2yo1enAUCdKcHcyxPJu2Gm3L5p35Q==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.5.2",
+        "escape-html": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.3.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.5.tgz",
-      "integrity": "sha512-ZLq6p5uyQXg+i1XGDFu4tAc2VYS12S1KA/jIOyyZjNgC1DvDajsi1JzuiBuOuMEhi1sKEUy6Ry3Yr9jsQtOKuQ==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.5.2.tgz",
+      "integrity": "sha512-qD98Amp/vWxCYMtv7yprh4Ry3QHFX50sf+i3E6e/WRquz+aUW2ilqmQqW6ucb4F2dlatUxMbOOhZOFazv2XLjg==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1226,8 +1239,7 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "tailwindcss": "^3.4.1"
   },
   "dependencies": {
+    "@contentful/rich-text-html-renderer": "^16.5.2",
     "@tailwindcss/typography": "^0.5.10",
     "clean-css": "^5.3.2",
     "contentful": "^10.8.9",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -192,6 +192,28 @@ figcaption svg {margin-right: 0.25rem;}
 
 
 /*--------------------------------------------------------------
+# About page
+--------------------------------------------------------------*/
+.iai-faqs__answer p {
+  margin-top: 1rem;
+}
+.iai-faqs__answer ul {
+  list-style-type: disc;
+  margin-top: 1rem;
+  padding-left: 1rem;
+}
+.iai-faqs__answer ul {
+  margin-top: 1rem;
+}
+.iai-faqs__answer a {
+  text-decoration: underline;
+}
+.iai-faqs__answer b {
+  font-weight: 500;
+}
+
+
+/*--------------------------------------------------------------
 # Join page
 --------------------------------------------------------------*/
 .iai-notification-buttons {

--- a/src/_data/faqs.js
+++ b/src/_data/faqs.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+const contentful = require('contentful');
+
+const client = contentful.createClient({
+    space: process.env.CONTENTFUL_SPACE,
+    accessToken: process.env.CONTENTFUL_ACCESS_TOKEN
+});
+  
+module.exports = () => {
+
+    return client.getEntries({
+        content_type: 'faQs'
+    }).then((response) => {
+
+        let faqs = response.items.map((role) => {
+            return role.fields;
+        });
+
+        faqs.sort((a, b) => {
+            return a.order - b.order;
+        });
+
+        return faqs;
+
+    }).catch((err) => {
+        console.error(err);
+    });
+
+};
+  

--- a/src/about.njk
+++ b/src/about.njk
@@ -132,72 +132,13 @@ templateEngineOverride: njk
     <div class="mt-5 md:w-[80%] font-light self-center" id="improve" data-aos="fade-up">
         
         <h2 class="text-[24px] font-semibold">Frequently Asked Questions</h2>
-    
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">What is the Incubator for AI (i.AI)?</h3></summary>
-            <p class="mt-3 text-[15px]">In November 2023, the Deputy Prime Minister established the ‘Incubator for AI’ or ‘i.AI’ (“I dot A I”), an elite team of highly empowered technical experts at the heart of government. Their mission is to help departments harness the potential of AI to improve lives and the delivery of public services.</p>
-            <p class="mt-3 text-[15px]">The early work of the Government’s AI incubator has already proven that it is possible to make effective AI tools for use in the UK Government, and that building these in-house can represent strong value for money. In a few short months, we have delivered the following pilot projects:</p>
-            <ul class="list-disc mt-3 pl-4 text-[15px]">
-                <li class="mt-3">A <a class="link" href="/projects/consultations">consultation response tool</a> that can read, summarise and triage the responses Government receives to the 700+ consultations that we initiate every year, saving up to £80m annually, and potentially freeing up time for us to undertake more engagement with the public on a broader range of issues.</li>
-                <li class="mt-3">A bespoke <a class="link" href="/projects/redbox-copilot">Civil Service AI assistant</a> called ‘Redbox Multitool’ (based on the Ministerial Redbox previously announced) which is tailored for the use of UK government, including a range of secure efficiency-generating features appropriate for central government work.</li>
-                <li class="mt-3"><a class="link" href="/projects/caddy">Caddy, an AI powered co-pilot</a> for customer service functions everywhere, currently in trial in Manchester. Built in collaboration with Citizens Advice, it seamlessly integrates into existing systems and provides expert advice to advisors and call handlers. Thanks to "double human in the loop" oversight, Caddy ensures a safe and continuously improving advice service.</li>
-                <li class="mt-3">Signing a <a class="link" href="/projects/nhs-collaboration">Collaboration Charter with NHSE</a> to work together on AI, as well as data infrastructure projects to support better operations in healthcare.</li>
-                <li class="mt-3">Other early pilot programs are, for example, targeting improving lives and saving costs in prescription medication, reducing asylum costs and streamlining access to the National Grid. More information will be released on these programs as they progress.</li>
-            </ul>
-            <p class="mt-3 text-[15px]">This team was initially established with 30 technical experts, working under the leadership of Dr Laura Gilbert, Downing Street’s Director of Data Science. In February, the Deputy Prime Minister announced an expansion of the team with an additional 40 staff who will focus on bringing these technical products to scale across government.</p>
-            <p class="mt-3 text-[15px]">The team is purely staffed by civil servants, most onboarding from the private sector or academia. There are no political roles.</p>
-        </details>
 
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">How do you choose projects?</h3></summary>
-            <p class="mt-3 text-[15px]">The incubator for AI (i.AI) takes AI ideas from ideation to delivery through structured assessment and rapid iteration. We source ideas from across the government, filter and prioritise them based on strategic value, technical feasibility and delivery capability, and scale their impact throughout government through re-usable code modules.</p>
-            <p class="mt-3 text-[15px]">i.AI acts as a true incubator sourcing, prioritising and closing projects. The incubator sources ideas from the Prime Minister and Deputy Prime Minister’s priorities, departmental suggestions, external engagement and internal ideation before filtering them through a series of checks to ensure we’re unlocking rapid value at scale. Checks include valuation of total potential impact, alignment with the Prime Minister and Deputy Prime Minister’s priorities, and feasibility across technical development and delivery chain. i.AI works in partnership with departments and where we are not best-placed to support we provide AI advisory and convening support.</p>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">Are you related to 10DS? What do they do?</h3></summary>
-            <p class="mt-3 text-[15px]">The No10 Data Science Team (10DS) works to improve the way in which key decisions are informed by data, analysis, and evidence using cutting-edge data science techniques. This enables the Government to use the best available evidence, throughout the policy and decision-making process, to drive long-term systems change and enable staff to collectively solve the most pressing policy and delivery challenges.</p>
-            <p class="mt-3 text-[15px]">10DS also runs a transformation program including:</p>
-            <ul class="list-disc mt-3 pl-4 text-[15px]">
-                <li class="mt-3">Project rAPId, a free, open source, lightweight data sharing system</li>
-                <li class="mt-3">The No10 Innovation Fellowships, bringing industry expertise in AI into central government on year-long secondments to improve public services</li>
-                <li class="mt-3">10X and Evidence House, programs to upskill civil servants in data science, AI and software engineering; and crowdsource technical solutions to ‘wicked problems’</li>
-                <li class="mt-3">Building and managing the new Incubator for Artificial Intelligence.</li>
-            </ul>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">Lots of teams are working on AI solutions. How is i.AI different?</h3></summary>
-            <p class="mt-3 text-[15px]">i.AI is an incubator, with an unusually high density of pure technical talent. We are set up to rapidly design, test and pilot ideas for the application of AI in government, and quickly learn what works. We are also empowered to operate with less “red tape” than other civil service teams often expect.</p>
-            <p class="mt-3 text-[15px]">However, many excellent teams across the public sector are joining us on our mission to harness AI for the public good - we value our partners and actively seek collaboration where we can work together to deliver better products, faster.</p>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">Why do we need to do this in-house when providers are already making tools to help productivity like Co-pilot or ChatGPT?</h3></summary>
-            <p class="mt-3 text-[15px]">External analysis suggests that the UK stands to gain around £40 billion per year in public sector productivity improvements by embracing AI, amounting to <a class="link" href="https://www.institute.global/insights/politics-and-governance/governing-in-the-age-of-ai-a-new-model-to-transform-the-state?utm_source=Social&utm_medium=Author&utm_campaign=fob_governing_ai_faculty">£200 billion over a five-year forecast</a> and could help <a class="link" href="https://www.turing.ac.uk/news/publications/ai-bureaucratic-productivity-measuring-potential-ai-help-automate-143-million-uk">automate around 84% of repetitive transactions across 200 government services</a>.This does mean that there is a place for use of off-the-shelf products, especially some of the productivity tools that are already provided by government IT contracts. However, many of these savings can only be achieved by building bespoke tools by government, for government. Building our own capability gives us the added benefit of increasing transparency and knowing exactly how our models are producing their outputs, therefore reducing the ‘black box effect’. In addition, bringing this type of expertise directly into government enables us to be more agile and respond more quickly to changing threats and opportunities.</p>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">How are you using AI to increase efficiency?</h3></summary>
-            <p class="mt-3 text-[15px]">Our AI tools are seeking opportunities to deliver better public services through the following mechanisms:</p>
-            <ul class="list-disc mt-3 pl-4 text-[15px]">
-                <li class="mt-3"><strong>Cost avoidance:</strong> We know that the public sector currently spends a lot of money on consultancy, contractors or waste. There is a place for this, but in some instances this could be replaced by automated work completed in-house by the civil service.</li>
-                <li class="mt-3"><strong>Identification of errors and fraud:</strong> AI can be used to identify error and fraud where public expenditure is leaking from the system in places that it should not.</li>
-                <li class="mt-3"><strong>A better quality service:</strong> We open up the possibility of net new capabilities that couldn’t be solved without AI. We scale best practices (e.g., virtual expertise) across the organisation bringing the best of the CS to everyone.</li>
-            </ul>
-            <p class="mt-3 text-[15px]">We’re focussed on supporting civil servants and surveys suggest that they are optimistic about the opportunities. In a <a class="link" href="https://arxiv.org/pdf/2401.01291">Turing survey of civil servants</a> earlier in 2024, it found that over 75% of respondents were optimistic about how AI will improve public services and only about 16% were worried that AI would eventually replace their current jobs.</p>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">Are there concerns about the sharing of personal data and personalisation?</h3></summary>
-            <p class="mt-3 text-[15px]">At i.AI, we take our duties under GDPR and the Data Protection Act very seriously. In line with the government’s <a class="link" href="https://www.gov.uk/government/publications/ai-regulation-a-pro-innovation-approach/white-paper#correction-slip">pro-innovation approach to AI regulation</a>, the standards we use are context-specific, meaning that our models will be assured based on the use case and the impact it has on individuals and groups. This approach makes use of regulators’ domain-specific expertise to tailor the implementation of the principles to the specific context in which AI is used.</p>
-        </details>
-
-        <details class="mt-5">
-            <summary><h3 class="inline text-[18px] font-semibold">How are your products guaranteed to be fair for all users?</h3></summary>
-            <p class="mt-3 text-[15px]">i.AI focuses primarily on early stage piloting of AI to deliver productivity improvements. We do not currently have any work in the pipeline that involves facial recognition, but we recognise the need for government services to be fully inclusive.</p>
-            <p class="mt-3 text-[15px]">All government departments are required by the government’s <a class="link" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a> to provide support via alternative channels for all their online services that are available to citizens. The government's <a class="link" href="https://www.gov.uk/government/publications/roadmap-for-digital-and-data-2022-to-2025/transforming-for-a-digital-future-2022-to-2025-roadmap-for-digital-and-data">Roadmap for Digital and Data</a> also includes enabling the confident and responsible use of AI to improve efficiency and services including accessibility requirements. i.AI focuses primarily on early stage piloting of AI to deliver productivity improvements.</p>
-        </details>
+        {% for faq in faqs %}
+            <details class="mt-5">
+                <summary><h3 class="inline text-[18px] font-semibold">{{ faq.question }}</h3></summary>
+                <div class="iai-faqs__answer text-[15px]">{{ faq.answer | richTextToHTML | safe }}
+            </details>
+        {% endfor %}
 
     </div>
 

--- a/src/about.njk
+++ b/src/about.njk
@@ -177,6 +177,28 @@ templateEngineOverride: njk
             <p class="mt-3 text-[15px]">External analysis suggests that the UK stands to gain around £40 billion per year in public sector productivity improvements by embracing AI, amounting to <a class="link" href="https://www.institute.global/insights/politics-and-governance/governing-in-the-age-of-ai-a-new-model-to-transform-the-state?utm_source=Social&utm_medium=Author&utm_campaign=fob_governing_ai_faculty">£200 billion over a five-year forecast</a> and could help <a class="link" href="https://www.turing.ac.uk/news/publications/ai-bureaucratic-productivity-measuring-potential-ai-help-automate-143-million-uk">automate around 84% of repetitive transactions across 200 government services</a>.This does mean that there is a place for use of off-the-shelf products, especially some of the productivity tools that are already provided by government IT contracts. However, many of these savings can only be achieved by building bespoke tools by government, for government. Building our own capability gives us the added benefit of increasing transparency and knowing exactly how our models are producing their outputs, therefore reducing the ‘black box effect’. In addition, bringing this type of expertise directly into government enables us to be more agile and respond more quickly to changing threats and opportunities.</p>
         </details>
 
+        <details class="mt-5">
+            <summary><h3 class="inline text-[18px] font-semibold">How are you using AI to increase efficiency?</h3></summary>
+            <p class="mt-3 text-[15px]">Our AI tools are seeking opportunities to deliver better public services through the following mechanisms:</p>
+            <ul class="list-disc mt-3 pl-4 text-[15px]">
+                <li class="mt-3"><strong>Cost avoidance:</strong> We know that the public sector currently spends a lot of money on consultancy, contractors or waste. There is a place for this, but in some instances this could be replaced by automated work completed in-house by the civil service.</li>
+                <li class="mt-3"><strong>Identification of errors and fraud:</strong> AI can be used to identify error and fraud where public expenditure is leaking from the system in places that it should not.</li>
+                <li class="mt-3"><strong>A better quality service:</strong> We open up the possibility of net new capabilities that couldn’t be solved without AI. We scale best practices (e.g., virtual expertise) across the organisation bringing the best of the CS to everyone.</li>
+            </ul>
+            <p class="mt-3 text-[15px]">We’re focussed on supporting civil servants and surveys suggest that they are optimistic about the opportunities. In a <a class="link" href="https://arxiv.org/pdf/2401.01291">Turing survey of civil servants</a> earlier in 2024, it found that over 75% of respondents were optimistic about how AI will improve public services and only about 16% were worried that AI would eventually replace their current jobs.</p>
+        </details>
+
+        <details class="mt-5">
+            <summary><h3 class="inline text-[18px] font-semibold">Are there concerns about the sharing of personal data and personalisation?</h3></summary>
+            <p class="mt-3 text-[15px]">At i.AI, we take our duties under GDPR and the Data Protection Act very seriously. In line with the government’s <a class="link" href="https://www.gov.uk/government/publications/ai-regulation-a-pro-innovation-approach/white-paper#correction-slip">pro-innovation approach to AI regulation</a>, the standards we use are context-specific, meaning that our models will be assured based on the use case and the impact it has on individuals and groups. This approach makes use of regulators’ domain-specific expertise to tailor the implementation of the principles to the specific context in which AI is used.</p>
+        </details>
+
+        <details class="mt-5">
+            <summary><h3 class="inline text-[18px] font-semibold">How are your products guaranteed to be fair for all users?</h3></summary>
+            <p class="mt-3 text-[15px]">i.AI focuses primarily on early stage piloting of AI to deliver productivity improvements. We do not currently have any work in the pipeline that involves facial recognition, but we recognise the need for government services to be fully inclusive.</p>
+            <p class="mt-3 text-[15px]">All government departments are required by the government’s <a class="link" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a> to provide support via alternative channels for all their online services that are available to citizens. The government's <a class="link" href="https://www.gov.uk/government/publications/roadmap-for-digital-and-data-2022-to-2025/transforming-for-a-digital-future-2022-to-2025-roadmap-for-digital-and-data">Roadmap for Digital and Data</a> also includes enabling the confident and responsible use of AI to improve efficiency and services including accessibility requirements. i.AI focuses primarily on early stage piloting of AI to deliver productivity improvements.</p>
+        </details>
+
     </div>
 
 </div>


### PR DESCRIPTION
## Changes proposed in this pull request

* Move FAQs to the CMS
* Adding 3 extra FAQs to the bottom of the About Page


## Things to check

- [ ] The 3 new FAQs read okay
- [x] Everything looks okay across different screen sizes
- [ ] The links work
