### PR TITLE
Update Redbox and Consult project pages

### DIFF
--- a/src/_data/projects.js
+++ b/src/_data/projects.js
@@ -1,6 +1,6 @@
 module.exports = [
-  {title: "Consultations", url: "/projects/consultations", img: "/img/consultation4.png", synopsis: "An AI-powered tool to automate the processing of public consultations"},
-  {title: "Redbox Copilot", url: "/projects/redbox-copilot", img: "/img/redbox3.png", synopsis: "Bringing Generative AI to the way the Civil Service works"},
+  {title: "Consult", url: "/projects/consultations", img: "/img/consultation4.png", synopsis: "An AI-powered tool to automate the processing of public consultations"},
+  {title: "Redbox", url: "/projects/redbox-copilot", img: "/img/redbox3.png", synopsis: "Bringing Generative AI to the way the Civil Service works"},
   {title: "Caddy", url: "/projects/caddy", img: "/img/caddy1.png", synopsis: "Our AI powered copilot for customer service agents across government and beyond"},
   {title: "rAPId", url: "/projects/rapid", img: "/img/rapid2.webp", synopsis: "An end-to-end solution to sharing data across government"},
   {title: "i.AI and NHS England Collaboration Charter", url: "/projects/nhs-collaboration", img: "/img/nhs1.jpg", synopsis: "i.AI and NHS England sign Collaboration Charter to support the use of AI in the NHS"}

--- a/src/projects/consultations.njk
+++ b/src/projects/consultations.njk
@@ -1,15 +1,15 @@
 ---
-title: Consultations
+title: Consult
 layout: base.njk
 templateEngineOverride: njk
-ogTitle: i.AI Consultation Analyser
+ogTitle: Consult
 ogImage: https://ai.gov.uk/img/consultation4.png
 ogUrl: https://ai.gov.uk/projects/consultations
 ---
 
 
 {% from "../_includes/banner.njk" import banner %}
-{{ banner("i.AI Consultation Analyser", "An AI-powered tool to automate the processing of public consultations") }}
+{{ banner("Consult", "An AI-powered tool to automate the processing of public consultations") }}
 
 
 <div class="container w-100 md:w-75 pt-[3rem]">

--- a/src/projects/redbox-copilot.njk
+++ b/src/projects/redbox-copilot.njk
@@ -12,17 +12,6 @@ ogUrl: https://ai.gov.uk/projects/redbox-copilot
 
 <div class="container w-100 md:w-75 pt-[3rem]">
 
-    <blockquote class="border-l-4 pl-4 lg:border-l-8 lg:pl-8 lg:py-4">
-        <p class="text-xl">“It will become, I believe, the institutional memory of the department.”</p>
-        <footer class="mt-2 text-sm">
-          Alex Burghart MP (Parliamentary Secretary for the Cabinet Office)
-          <dl>
-            <dt class="font-bold inline-block">Source:</dt>
-            <dd class="font-normal inline-block ml-1"><a class="link" href="https://www.bbc.co.uk/news/uk-politics-67944529">https://www.bbc.co.uk/news/uk-politics-67944529</a> (11th Jan 2024)</dd>
-          </dl>
-        </footer>
-    </blockquote>
-
     <div class="gap-8 grid-cols-2 items-center mt-10 lg:grid">
         <div>
             <p>The ministerial redbox has been the primary destination for state papers since they came into government in the mid-19th century. Redbox Copilot was initially envisioned as a way to leverage AI to search through thousands of documents, interrogate them and summarise them into tailored briefings.</p>

--- a/src/projects/redbox-copilot.njk
+++ b/src/projects/redbox-copilot.njk
@@ -1,14 +1,14 @@
 ---
-title: Redbox Copilot
+title: Redbox
 layout: base.njk
 templateEngineOverride: njk
-ogTitle: Redbox Copilot
+ogTitle: Redbox
 ogImage: https://ai.gov.uk/img/redbox3.png
 ogUrl: https://ai.gov.uk/projects/redbox-copilot
 ---
 
 {% from "../_includes/banner.njk" import banner %}
-{{ banner("Redbox Copilot", "Bringing Generative AI to the way the Civil Service works") }}
+{{ banner("Redbox", "Bringing Generative AI to the way the Civil Service works") }}
 
 <div class="container w-100 md:w-75 pt-[3rem]">
 


### PR DESCRIPTION
## Context

Updates to project pages


## Changes proposed in this pull request

* Update Consult and Redbox page titles
* Remove quote from Redbox page


## Things to check

* Check "Redbox" appears everywhere instead of "Redbox Copilot". The image/logo is an exception and has been okayed as is, for now.

* Check "Consult" appears everywhere instead of "Consultations".

* Check the quote at the top of the Redbox page is no longer there.
