### PR TITLE
Feature/blogs tweaks

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1533,8 +1533,15 @@ figcaption svg {
 .iai-blogs-list {
   display: grid;
   gap: 2rem;
-  padding-bottom: 2rem;
   padding-top: 3rem;
+}
+.iai-blogs-list-item {
+  border-top: 1px solid var(--iai-pink);
+  padding-top: 2.5rem;
+}
+.iai-blogs-list-item:first-child {
+  border: none;
+  padding-top: 0;
 }
 .iai-blogs-list__cover-image {
   aspect-ratio: 16/9;
@@ -1560,6 +1567,12 @@ figcaption svg {
   font-size: 0.875rem;
   font-weight: 400;
   margin-top: 0.125rem;
+}
+@media (min-width: 68rem) {
+  .iai-blogs-list-item {
+    border: none;
+    padding-top: 0;
+  }
 }
 
 .iai-blog-title {

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -15,11 +15,16 @@
         <meta content="" name="description">
         <meta content="" name="keywords">
 
+        {% if blog.title and blog.coverImage.file.url %}
+            {% set ogTitle = blog.title %}
+            {% set ogImage = "https:" + blog.coverImage.file.url %}
+            {% set ogUrl = "blogs/" + blog.title | slugify %}
+        {% endif %}
         {% if ogTitle and ogImage and ogUrl %}
-          <meta property="og:title" content="{{ogTitle}}">
+          <meta property="og:title" content="{{ ogTitle }}">
           <meta property="og:type" content="website">
-          <meta property="og:image" content="{{ogImage}}">
-          <meta property="og:url" content="{{ogUrl}}">
+          <meta property="og:image" content="{{ ogImage }}">
+          <meta property="og:url" content="{{ ogUrl }}">
           <meta property="og:site_name" content="Incubator for Artificial Intelligence - GOV.UK">
         {% endif %}
 

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -6,6 +6,7 @@ pagination:
     size: 1
     alias: blog
 permalink: "blogs/{{ blog.title | slugify }}/"
+# Note: If permalink changes - also update in base.njk
 ---
 
 {% from "./_includes/blog-header.njk" import blogHeader %}

--- a/src/blogs.njk
+++ b/src/blogs.njk
@@ -11,7 +11,7 @@ templateEngineOverride: njk
 
 <div class="iai-blogs-list container">
     {% for blog in blogs %}
-        <a href="/blogs/{{ blog.title | slugify  }}">
+        <a class="iai-blogs-list-item" href="/blogs/{{ blog.title | slugify  }}">
             <img class="iai-blogs-list__cover-image" src="{{ blog.coverImage.file.url }}?w=2200" alt=""/>
             <h2 class="iai-blogs-list__title" >{{ blog.title }}</h2>
             <p class="iai-blog-list__summary">{{ blog.summaryShort }}</p>


### PR DESCRIPTION
## Changes proposed in this pull request

* Adding in OG metadata for blog posts (so title, image etc. are visible when adding to social media)
* Improving mobile layout on the blogs hub page by adding a horizontal spacer between blogs


## Guidance to review

* The OG `<meta>` tags are present in the `<head>` for blog posts
* `/blogs` looks okay on mobile