### PR TITLE
Remember if details were previous open

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -125,3 +125,35 @@ class inpageLink extends HTMLElement {
   }
 }
 customElements.define('inpage-link', inpageLink);
+
+
+/**
+ * Remembers if the details were previous opened - useful if navigating back from a page linked to within
+ */
+class DetailsEnhanced extends HTMLElement {
+
+  connectedCallback() {
+    
+    const id = `details-${this.querySelector("summary")?.textContent?.toLowerCase().replace(/[^a-z0-9_-]/g, '')}`;
+    let detailsEl = this.querySelector("details");
+
+    if (!id || !detailsEl) {
+      return;
+    }
+
+    if (window.sessionStorage.getItem(id)) {
+      detailsEl.setAttribute("open", "");
+    }
+
+    detailsEl.addEventListener("toggle", () => {
+      if (detailsEl?.open) {
+        window.sessionStorage.setItem(id, "open");
+      } else {
+        window.sessionStorage.removeItem(id);
+      }
+    });
+
+  }
+
+}
+customElements.define('details-enhanced', DetailsEnhanced);

--- a/src/about.njk
+++ b/src/about.njk
@@ -71,10 +71,12 @@ templateEngineOverride: njk
         <h2 class="text-[24px] font-semibold">Frequently Asked Questions</h2>
 
         {% for faq in faqs %}
-            <details class="mt-5">
-                <summary><h3 class="inline text-[18px] font-semibold">{{ faq.question }}</h3></summary>
-                <div class="iai-faqs__answer text-[15px]">{{ faq.answer | richTextToHTML | safe }}
-            </details>
+            <details-enhanced>
+                <details class="mt-5">
+                    <summary><h3 class="inline text-[18px] font-semibold">{{ faq.question }}</h3></summary>
+                    <div class="iai-faqs__answer text-[15px]">{{ faq.answer | richTextToHTML | safe }}
+                </details>
+            </details-enhanced>
         {% endfor %}
 
     </div>


### PR DESCRIPTION
## Context

We have a number of `<details>` elements on the `/about` page that contain links inside. @rachaelcodes has helpfully flagged that if a user follows a link, then returns back to the `/about` page, then the details are closed again. This could make it difficult for a user to remember where they are.


## Changes proposed in this pull request

This work creates a `<details-enhanced>` web-component/wrapper that remembers which `<details>` are open (for the duration of that session).


## Guidance to review

Navigate to the bottom of the `/about` page and have a play!
