### PR TITLE
Add og:description and Twitter meta tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -47,6 +47,16 @@ module.exports = function (eleventyConfig) {
     return `${day} ${month} ${year}`;
   });
 
+  eleventyConfig.addFilter("preventOrphans", (text) => {
+    const lastSpaceIndex = text.lastIndexOf(" ");
+    if (lastSpaceIndex === -1) {
+      return text;
+    }
+    const beforeSpace = text.substring(0, lastSpaceIndex);
+    const afterSpace = text.substring(lastSpaceIndex + 1);
+    return `${beforeSpace}&nbsp;${afterSpace}`;
+  });
+
   eleventyConfig.addFilter("richTextToHTML", (value) => {
     return documentToHtmlString(value, {
       renderNode: {

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -19,13 +19,20 @@
             {% set ogTitle = blog.title %}
             {% set ogImage = "https:" + blog.coverImage.file.url %}
             {% set ogUrl = "blogs/" + blog.title | slugify %}
+            {% set ogDescription = blog.summaryShort %}
         {% endif %}
-        {% if ogTitle and ogImage and ogUrl %}
-          <meta property="og:title" content="{{ ogTitle }}">
-          <meta property="og:type" content="website">
-          <meta property="og:image" content="{{ ogImage }}">
-          <meta property="og:url" content="{{ ogUrl }}">
-          <meta property="og:site_name" content="Incubator for Artificial Intelligence - GOV.UK">
+        {% if ogTitle and ogImage and ogUrl and ogDescription %}
+            <meta property="og:title" content="{{ ogTitle }}">
+            <meta property="og:type" content="website">
+            <meta property="og:image" content="{{ ogImage }}">
+            <meta property="og:url" content="{{ ogUrl }}">
+            <meta property="og:description" content="{{ ogDescription }}">
+            <meta property="og:site_name" content="Incubator for Artificial Intelligence - GOV.UK">
+            <meta name="twitter:card" content="summary_large_image">
+            <meta name="twitter:site" content="@i_dot_ai">
+            <meta name="twitter:title" content="{{ ogTitle }}">
+            <meta name="twitter:description" content="{{ ogDescription }}">
+            <meta name="twitter:image" content="{{ ogImage }}">
         {% endif %}
 
         <link href="/img/favicon.ico" rel="icon">

--- a/src/projects/caddy.njk
+++ b/src/projects/caddy.njk
@@ -5,11 +5,12 @@ templateEngineOverride: njk
 ogTitle: Caddy
 ogImage: https://ai.gov.uk/img/caddy1.png
 ogUrl: https://ai.gov.uk/projects/caddy
+ogDescription: "Caddy is our AI powered co-pilot for customer service functions everywhere. Built in collaboration with Citizens Advice, it seamlessly integrates into existing systems and provides expert advice to advisors and call handlers. Thanks to \"human in the loop\" oversight, Caddy ensures a safe and continuously improving advice service."
 ---
 
 {% from "../_includes/banner.njk" import banner %}
 {% from "../_includes/text-image-block.njk" import textImageBlock %}
-{{ banner("Caddy", "Caddy is our AI powered co-pilot for customer service functions everywhere. Built in collaboration with Citizens Advice, it seamlessly integrates into existing systems and provides expert advice to advisors and call handlers. Thanks to \"human in the loop\" oversight, Caddy ensures a safe and continuously improving advice service.") }}
+{{ banner("Caddy", ogDescription) }}
 
 <div class="container w-100 md:w-75 pt-[2rem]">
 

--- a/src/projects/consult.njk
+++ b/src/projects/consult.njk
@@ -5,11 +5,12 @@ templateEngineOverride: njk
 ogTitle: Consult
 ogImage: https://ai.gov.uk/img/consultation4.png
 ogUrl: https://ai.gov.uk/projects/consult
+ogDescription: "An AI-powered tool to automate the processing of public consultations"
 ---
 
 
 {% from "../_includes/banner.njk" import banner %}
-{{ banner("Consult", "An AI-powered tool to automate the processing of public consultations") }}
+{{ banner("Consult", ogDescription) }}
 
 
 <div class="container w-100 md:w-75 pt-[3rem]">

--- a/src/projects/nhs-collaboration.njk
+++ b/src/projects/nhs-collaboration.njk
@@ -5,6 +5,7 @@ templateEngineOverride: njk
 ogTitle: i.AI and NHS England Collaboration Charter
 ogImage: https://ai.gov.uk/img/nhs2.png
 ogUrl: https://ai.gov.uk/projects/nhs-collaboration
+ogDescription: "i.AI and NHS England sign Collaboration Charter to support the use of AI in the NHS"
 ---
 
 {% from "../_includes/banner.njk" import banner %}

--- a/src/projects/nhs-collaboration.njk
+++ b/src/projects/nhs-collaboration.njk
@@ -10,7 +10,7 @@ ogDescription: "i.AI and NHS England sign Collaboration Charter to support the u
 
 {% from "../_includes/banner.njk" import banner %}
 {% from "../_includes/text-image-block.njk" import textImageBlock %}
-{{ banner("i.AI and NHS England Collaboration Charter", "i.AI and NHS England sign Collaboration Charter to support the use of AI in the&nbsp;NHS") }}
+{{ banner("i.AI and NHS England Collaboration Charter", ogDescription | preventOrphans) }}
 
 <div class="container w-100 md:w-75 pt-[2rem]">
 

--- a/src/projects/rapid.njk
+++ b/src/projects/rapid.njk
@@ -5,11 +5,12 @@ templateEngineOverride: njk
 ogTitle: rAPId
 ogImage: https://ai.gov.uk/img/rapid2.webp
 ogUrl: https://ai.gov.uk/projects/rapid
+ogDescription: "An end-to-end solution to sharing data across government"
 ---
 
 {% from "../_includes/banner.njk" import banner %}
 {% from "../_includes/text-image-block.njk" import textImageBlock %}
-{{ banner("rAPId", "An end-to-end solution to sharing data across government") }}
+{{ banner("rAPId", ogDescription) }}
 
 <div class="container w-100 md:w-75 pt-[2rem]">
 

--- a/src/projects/redbox.njk
+++ b/src/projects/redbox.njk
@@ -5,10 +5,11 @@ templateEngineOverride: njk
 ogTitle: Redbox
 ogImage: https://ai.gov.uk/img/redbox4.png
 ogUrl: https://ai.gov.uk/projects/redbox
+ogDescription: "Bringing Generative AI to the way the Civil Service works"
 ---
 
 {% from "../_includes/banner.njk" import banner %}
-{{ banner("Redbox", "Bringing Generative AI to the way the Civil Service works") }}
+{{ banner("Redbox", ogDescription) }}
 
 <div class="container w-100 md:w-75 pt-[3rem]">
 


### PR DESCRIPTION
## Context

We're having trouble getting preview images to appear when adding bog/project page links to Twitter and other social media.

## Changes proposed in this pull request

* Add og:description meta tag (I think this is the primary issue)
* Add Twitter meta tags (I don't think this is essential, but why not)


## Guidance to review

Go to a blog page and inspect the `<head>` - you should see all the various og and Twitter meta tags in there.


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
