### PR TITLE
Return empty array if fetching data from DecapCMS fails

### DIFF
--- a/src/_data/blogs.js
+++ b/src/_data/blogs.js
@@ -34,6 +34,7 @@ async function getData(url) {
         return (response.data);
     } catch (error) {
         console.error(`Error fetching for URL: ${url}`, error.message);
+        return [];
     }
 }
 


### PR DESCRIPTION
## Context

The build was failing because of missing `GITHUB_TOKEN` env. I'm not too worried about that while we're still testing, but this will fix the Eleventy build error that was being thrown as a result.


## Changes proposed in this pull request

* Return an empty array if `getData()` fails


## Guidance to review

* It should build now


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
