### PR TITLE
Split FAQs into sections

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1272,6 +1272,33 @@ figcaption svg {
 /*--------------------------------------------------------------
 # About
 --------------------------------------------------------------*/
+.iai-faqs__section {
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 3rem;
+}
+.iai-faqs__section:last-child {
+  border-bottom: 0;
+}
+.iai-faqs ol {
+  list-style: auto;
+  margin-top: 0.5rem;
+  padding-left: 2rem;
+}
+.iai-faqs ol li {
+  padding: 0.5rem 0;
+}
+.iai-faqs a {
+  text-underline-offset: 4px;
+}
+.iai-faqs a:hover {
+  color: var(--iai-pink);
+  text-decoration: underline;
+}
+.iai-faqs strong {
+  font-weight: 700;
+}
+
+
 .iai-teams {
   padding: 3rem 0;
 }

--- a/src/_data/_shared.js
+++ b/src/_data/_shared.js
@@ -1,0 +1,22 @@
+require("dotenv").config();
+const axios = require("axios");
+
+/**
+ * Gets file data from Github
+ * @param {string} url 
+ * @returns {object}
+ */
+module.exports.getData = async (url) => {
+    try {
+        const response = await axios.get(url, {
+            headers: {
+                "Authorization": `token ${process.env.GITHUB_TOKEN}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        });
+        return (response.data);
+    } catch (error) {
+        console.error(`Error fetching for URL: ${url}`, error.message);
+        return [];
+    }
+};

--- a/src/_data/blogs.js
+++ b/src/_data/blogs.js
@@ -4,6 +4,7 @@ const path = require('path');
 const contentful = require('contentful');
 const axios = require('axios');
 const matter = require('gray-matter');
+const getData = require("./_shared.js").getData;
 
 const USE_PREVIEW = false;
 const CMS_REPO = "i-dot-ai/ai-gov-uk-cms-content";
@@ -16,27 +17,6 @@ if (USE_PREVIEW) {
     contentfulOptions.host = 'preview.contentful.com';
 }
 const client = contentful.createClient(contentfulOptions);
-
-
-/**
- * Gets file data from Github
- * @param {string} url 
- * @returns {object}
- */
-async function getData(url) {
-    try {
-        const response = await axios.get(url, {
-            headers: {
-                'Authorization': `token ${process.env.GITHUB_TOKEN}`,
-                "X-GitHub-Api-Version": "2022-11-28",
-            }
-        });
-        return (response.data);
-    } catch (error) {
-        console.error(`Error fetching for URL: ${url}`, error.message);
-        return [];
-    }
-}
 
 
 /**

--- a/src/_data/faqs.js
+++ b/src/_data/faqs.js
@@ -1,30 +1,17 @@
-require('dotenv').config();
-const contentful = require('contentful');
+const matter = require("gray-matter");
+const getData = require("./_shared.js").getData;
 
-const client = contentful.createClient({
-    space: process.env.CONTENTFUL_SPACE,
-    accessToken: process.env.CONTENTFUL_ACCESS_TOKEN
-});
+const CMS_REPO = "i-dot-ai/ai-gov-uk-cms-content";
+
   
-module.exports = () => {
+module.exports = async () => {
 
-    return client.getEntries({
-        content_type: 'faQs'
-    }).then((response) => {
+    const faqsFetch = await getData(`https://api.github.com/repos/${CMS_REPO}/contents/content/faqs`);
+    const faqsRawData = await getData(faqsFetch[0].url);
+    const faqsData = Buffer.from(faqsRawData.content, "base64").toString("utf8");
+    const faqs = matter(faqsData).data;
 
-        let faqs = response.items.map((role) => {
-            return role.fields;
-        });
-
-        faqs.sort((a, b) => {
-            return a.order - b.order;
-        });
-
-        return faqs;
-
-    }).catch((err) => {
-        console.error(err);
-    });
+    return faqs;
 
 };
   

--- a/src/about.njk
+++ b/src/about.njk
@@ -9,9 +9,7 @@ templateEngineOverride: njk
 
 <div class="container flex flex-col w-100 md:w-75 pt-[4rem]">
 
-    <div class="flex flex-col md:flex-col lg:flex-row w-[100%] md:w-[80%] self-center" id="improve" data-aos="fade-up">
-        <h2 class="text-[24px] font-semibold">We have four key functions</h2>
-    </div>
+    <h2 class="text-[24px] font-semibold text-center">We have four key functions</h2>
 
     <div class="flex flex-col md:flex-col lg:flex-row w-[100%] md:w-[80%] self-center border-b border-grey-300 pb-5 pt-5" id="improve" data-aos="fade-up">
         <div class="flex flex-col items-end pr-12 lg:w-[20%] md:w-[100%]">
@@ -66,17 +64,22 @@ templateEngineOverride: njk
     </div>
 
 
-    <div class="mt-5 md:w-[80%] font-light self-center" id="improve" data-aos="fade-up">
+    <div class="iai-faqs mt-5 md:w-[80%] font-light self-center" id="improve" data-aos="fade-up">
         
-        <h2 class="text-[24px] font-semibold">Frequently Asked Questions</h2>
+        <h2 class="text-[24px] font-semibold text-center">{{ faqs.title }}</h2>
 
-        {% for faq in faqs %}
-            <details-enhanced>
-                <details class="mt-5">
-                    <summary><h3 class="inline text-[18px] font-semibold">{{ faq.question }}</h3></summary>
-                    <div class="iai-faqs__answer text-[15px]">{{ faq.answer | richTextToHTML | safe }}
-                </details>
-            </details-enhanced>
+        {% for section in faqs.headings %}
+            <div class="iai-faqs__section">
+                <h3 class="text-[20px] font-semibold mt-5">{{ section.heading }}</h3>
+                {% for question in section.questions %}
+                    <details-enhanced>
+                        <details class="mt-5">
+                            <summary><h3 class="inline text-[16px] font-semibold">{{ question.question.questionText }}</h3></summary>
+                            <div class="iai-faqs__answer text-[15px]">{{ question.question.response | markdownToHtml | safe }}
+                        </details>
+                    </details-enhanced>
+                {% endfor %}
+            </div>
         {% endfor %}
 
     </div>


### PR DESCRIPTION
## Context

The new FAQs are split into sections with a heading for each section. As part of this change, it made sense to move this over to the new CMS.


## Changes proposed in this pull request

* Setup FAQs in Decap CMS
* Add sections/headings


## Guidance to review

Visit the about page and check the FAQs look okay


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
