### PR TITLE
Remove Glasgow and York from digital hubs (requested by Harri)

### DIFF
--- a/src/join.njk
+++ b/src/join.njk
@@ -123,13 +123,11 @@ templateEngineOverride: njk
 <section class="iai-locations">
     <div class="container">
         <h2 class="iai-heading">Locations</h2>
-        <p>Our team is based out of 5 digital hubs across the UK in:</p>
+        <p>Our team is based out of 3 digital hubs across the UK in:</p>
         <ul class="iai-list">
             <li class="iai-list__item">Bristol</li>
             <li class="iai-list__item">London</li>
-            <li class="iai-list__item">Glasgow</li>
             <li class="iai-list__item">Manchester</li>
-            <li class="iai-list__item">York</li>
         </ul>
     </div>
 </section>


### PR DESCRIPTION
## Context

Removed a couple of digital hub locations as requested by Harri


## Guidance to review

Only Bristol, London and Manchester should be listed on the Join page


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
