### PR TITLE
Restrict bucket access to CloudFront

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,3 +23,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -19,6 +19,11 @@ resource "aws_cloudfront_distribution" "website" {
         "TLSv1.2"
       ]
     }
+
+    custom_header {
+      name  = "Referer"
+      value = random_password.cloudfront_identifier.result
+    }
   }
 
   enabled     = true

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,36 +11,11 @@ data "aws_iam_policy_document" "website" {
       type        = "*"
       identifiers = ["*"]
     }
-  }
+    condition {
+      test     = "StringLike"
+      variable = "aws:Referer"
 
-  dynamic "statement" {
-    for_each = toset(var.web_domain_hostnames)
-
-    content {
-      effect = "Allow"
-      actions = [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-      ]
-      resources = [
-        aws_s3_bucket.website.arn,
-        "${aws_s3_bucket.website.arn}/*",
-      ]
-      principals {
-        type        = "*"
-        identifiers = ["*"]
-      }
-      condition {
-        test     = "StringLike"
-        variable = "aws:Referer"
-
-        values = flatten([
-          for host in var.web_domain_hostnames : [
-            "http://${host}/*",
-            "https://${host}/*"
-          ]
-        ])
-      }
+      values = [random_password.cloudfront_identifier.result]
     }
   }
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   required_version = "~> 1.0"

--- a/terraform/random.tf
+++ b/terraform/random.tf
@@ -1,0 +1,4 @@
+resource "random_password" "cloudfront_identifier" {
+  length  = 32
+  special = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,13 +28,13 @@ variable "website_bucket_deployment_roles" {
   description = "ARNs with permitted access to the bucket to deploy bucket contents"
 }
 
-variable s3_redirection_rules {
+variable "s3_redirection_rules" {
   type = map(object({
-    key_prefix_equals        = string
-    host_name                = string
-    http_redirect_code       = string
-    protocol                 = string
-    replace_key_prefix_with  = string
+    key_prefix_equals       = string
+    host_name               = string
+    http_redirect_code      = string
+    protocol                = string
+    replace_key_prefix_with = string
   }))
   description = "A set of rules to provide to S3 for request redirects"
 }


### PR DESCRIPTION
## Context

This PR prevents direct public access to the S3 bucket hosting the website. CloudFront injects a header which is evaluated by the bucket policy.
These changes are in lieu of using CloudFront OAC/OAI due to limitations of the current configuration around S3 static website hosting.

## Changes proposed in this pull request

Implements a header passed to the S3 origin and evaluated on the bucket policy.

## Guidance to review

<-- How can someone who is reviewing this see your changes or reproduce the fix -->

## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
