### PR TITLE
Remove link to expired register-interest form

### DIFF
--- a/src/join.njk
+++ b/src/join.njk
@@ -171,6 +171,7 @@ templateEngineOverride: njk
 </section>
 #}
 
+{#
 <section class="w-100 flex flex-col pb-3 pt-[4rem] m-0">
     <div class="container flex flex-col text-center w-75" data-aos="fade-up">
       <h2 class="text-[23px] font-semibold">Register your interest{% if jobs.length %} in other roles{% endif %}</h2>
@@ -178,3 +179,4 @@ templateEngineOverride: njk
       <a href="https://www.smartsurvey.co.uk/s/H4EHGB/" class="text-white bg-[#000] align-items-center mx-auto mt-4 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 font-semibold h-12 px-6 rounded-lg flex items-center justify-center align-items-center">Register your interest</a>
     </div>
 </section>
+#}


### PR DESCRIPTION
## Context

The "Register your interest" form has expired. It's been decided to remove this section from the website as we now want to encourage people to sign up for alerts directly in CS Jobs.

I've just commented it out for now, in case we ever want to add it back in again.


## Guidance to review

Check the link has been removed from the bottom of the Join page


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
