### PR TITLE
Add message about job applications

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -35,6 +35,10 @@ h6,
   text-decoration: underline;
 }
 
+.iai-link:hover {
+  color: var(--iai-pink);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/src/join.njk
+++ b/src/join.njk
@@ -58,6 +58,7 @@ templateEngineOverride: njk
                     </div>
                 </div>
             {% endfor %}
+            <p class="mt-5 font-light">We can only accept applications via the <a class="link iai-link" href="https://www.civilservicejobs.service.gov.uk/csr/index.cgi?SID=b3duZXJ0eXBlPWZhaXImcGFnZWNsYXNzPVNlYXJjaCZjb250ZXh0aWQ9MTAxNjYzMjcxJnBhZ2VhY3Rpb249c2VhcmNoY29udGV4dCZvd25lcj01MDcwMDAwJnJlcXNpZz0xNzI5NTA5NDU4LTdjZmQwMGQ5MDQ3OWE5NzU2MTA4NGY2MDFiZjQzOGQwMGM0ZmViMjk=">Civil Service Jobs website<a/>.</p>
         </div>
     </section>
 {% endif %}


### PR DESCRIPTION
## Context

Just a small change for now to make it clear all job applications need to be made via the Civil Service jobs website (following feedback).


## Changes proposed in this pull request

Just adding this line:

![image](https://github.com/user-attachments/assets/b0f2b652-d0f5-4a61-82b3-2dc04c3a70c4)


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
