### PR TITLE
Add latest 3 blogs to the homepage

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -396,6 +396,17 @@ figcaption svg {
   }
 }
 
+.iai-homepage-blogs {
+  background-color: var(--iai-grey);
+  margin-top: 2rem;
+  padding-bottom: 3rem;
+  padding-top: 0.125rem;
+}
+.iai-homepage-blogs h2 {
+  font-size: 2rem;
+  margin-bottom: -1rem;
+}
+
 /*--------------------------------------------------------------
 # Projects page cards
 --------------------------------------------------------------*/
@@ -1430,6 +1441,9 @@ figcaption svg {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 1.5rem;
+}
+.iai-blogs-list-item:hover .iai-blogs-list__title {
+  color: var(--iai-pink);
 }
 .iai-blog-list__summary {
   font-size: 1rem;

--- a/src/index.njk
+++ b/src/index.njk
@@ -114,6 +114,29 @@ templateEngineOverride: njk
 </div>
 
 
+<section class="iai-homepage-blogs">
+  <div class="container">
+    <h2 class="block mt-5 font-semibold text-center">Latest Blogs</h2>
+  </div>
+  <div class="iai-blogs-list container">
+    {% set count = 0 %}
+    {% for blog in blogs %}
+        {% if blog.summaryShort and count < 3 %} {# This ensures the CMS preview blog isn't displayed here #}
+          {% set count = count + 1 %}
+          <a class="iai-blogs-list-item" href="/blogs/{{ blog.title | slugify  }}" data-aos="fade-up">
+            <div class="iai-blogs-list__image-container">
+              <img class="iai-blogs-list__cover-image" src="{{ blog.coverImage.file.url }}?w=1536" alt=""/>
+            </div>
+            <h3 class="iai-blogs-list__title" >{{ blog.title }}</h3>
+            <p class="iai-blog-list__summary">{{ blog.summaryShort }}</p>
+            <p class="iai-blog-list__date">{{ blog.date | dateFormat }}</p>
+          </a>
+        {% endif %}
+    {% endfor %}
+  </div>
+</section>
+
+
 <div class="container flex w-90 my-5 md:w-75 gap-5">
   <div class="flex gap-3 align-center justify-center text-center w-full">
     <div class="flex flex-col mt-3 gap-4 text-center items-center">


### PR DESCRIPTION
## Context

We would like to add the top 3 latest blogs to the homepage


## Changes proposed in this pull request

It should now look like this:
<img src="https://github.com/user-attachments/assets/cbf3d7b3-591f-4d24-bf20-c1459af0265c" width="200"/>


## Guidance to review

Check it looks okay across various screen sizes and the links work


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
