### PR TITLE
Tweak name of search box

### DIFF
--- a/src/knowledge-hub/use-cases.njk
+++ b/src/knowledge-hub/use-cases.njk
@@ -28,7 +28,7 @@ title: Use cases
 
     <details class="govuk-!-margin-top-7 govuk-!-padding-left-6 govuk-!-padding-right-6 govuk-!-padding-top-4 govuk-!-padding-bottom-4" style="border: 1px solid #c50878; background-color: #fee7f4;">
       <summary>
-        <h2 class="govuk-heading-m govuk-!-display-inline-block govuk-!-margin-left-2 govuk-!-margin-bottom-0" style="vertical-align: sub;">Search &amp; Filters</h2>
+        <h2 class="govuk-heading-m govuk-!-display-inline-block govuk-!-margin-left-2 govuk-!-margin-bottom-0" style="vertical-align: sub;">Search and filter</h2>
       </summary>
       <usecase-filters class="govuk-!-display-block govuk-!-margin-top-4"></usecase-filters>
     </details>


### PR DESCRIPTION
Change from 'Search & Filters' to 'Search and filter'.

Rationale:
- gov.uk convention is sentence case, not title case
- we should only use & when space dictates it
- switch from noun-phrase to verb-phrase to make it action-oriented
