### PR TITLE
Use webp for images from Decap CMS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -178,6 +178,9 @@ module.exports = function (eleventyConfig) {
           image.replace(
             "/images/uploads",
             "https://i-dot-ai-cms.netlify.app/assets"
+          ).replace(
+            // Add .webp to end of image path (for most optimised image)
+            /(<img\b[^>]*\ssrc=")([^"]+?)(?<!\.webp)(")/gi,(_, prefix, url, quote) => `${prefix}${url}.webp${quote}`
           )
         );
       }

--- a/src/_includes/blog-author.njk
+++ b/src/_includes/blog-author.njk
@@ -1,7 +1,12 @@
-{% macro blogAuthor (author, size="small") %}
+{% macro blogAuthor (author, size="small", source) %}
     <div class="iai-blog-author">
         {% if author.picture %}
-            <img class="iai-blog-author__image iai-blog-author__image--{{size}}" src="{{ author.picture.fields.file.url }}?w=96" alt="" loading="lazy"/>
+            {% if source == 'DecapCMS' %}
+                {% set imagePath = author.picture.fields.file.url + '.webp' %}
+            {% else %}
+                {% set imagePath = author.picture.fields.file.url + '?w=96' %}
+            {% endif %}
+            <img class="iai-blog-author__image iai-blog-author__image--large" src="{{ imagePath }}" alt="" loading="lazy"/>
         {% endif %}
         <div>
             <span class="iai-blog-author__name">{{ author.name }}</span>

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -22,11 +22,11 @@ permalink: "blogs/{{ blog.title | slugify }}/"
         <p class="iai-blog-title__date">{{ blog.date | dateFormat }}</p>
         <div class="d-md-flex gap-5">
             {% for author in blog.authors %}
-                {{ blogAuthor (author, "large") }}
+                {{ blogAuthor (author, blog.source) }}
             {% endfor %}
         </div>
         {% if blog.summaryLong %}
-            <p class="iai-blog-title__summary">{{ blog.summaryLong }}</p>
+            <p class="iai-blog-title__summary govuk-!-margin-top-6">{{ blog.summaryLong }}</p>
         {% endif %}
     </div>
 
@@ -35,13 +35,20 @@ permalink: "blogs/{{ blog.title | slugify }}/"
         <div class="iai-blog-content__inner-container">
 
             <div class="iai-blog-title__cover-image-container">
+
+                {% if blog.source == 'DecapCMS' %}
+                    {% set coverImagePath = blog.coverImage.file.url + '.webp' %}
+                {% else %}
+                    {% set coverImagePath = blog.coverImage.file.url + '?w=1536' %}
+                {% endif %}
+
                 {% if blog.coverImage.title %}
                     <figure>
-                        <img class="iai-blog-title__cover-image" src="{{ blog.coverImage.file.url }}?w=1536" alt="{{ blog.coverImage.description }}"/>
+                        <img class="iai-blog-title__cover-image" src="{{ coverImagePath }}" alt="{{ blog.coverImage.description }}"/>
                         <figcaption class="iai-blog-title__figcaption">{{ blog.coverImage.title }}</figcaption>
                     </figure>
                 {% else %}
-                    <img class="iai-blog-title__cover-image" src="{{ blog.coverImage.file.url }}?w=1536" alt="{{ blog.coverImage.description }}"/>
+                    <img class="iai-blog-title__cover-image" src="{{ coverImagePath }}" alt="{{ blog.coverImage.description }}"/>
                 {% endif %}
             </div>
 

--- a/src/blogs.njk
+++ b/src/blogs.njk
@@ -5,7 +5,6 @@ templateEngineOverride: njk
 ---
 
 {% from "./_includes/banner.njk" import banner %}
-{% from "./_includes/blog-author.njk" import blogAuthor %}
 {% from "./_includes/card.njk" import card %}
 
 
@@ -20,8 +19,14 @@ templateEngineOverride: njk
 			{% for blog in blogs %}
 				{% if blog.summaryShort %} {# This ensures the CMS preview blog isn't displayed here #}
 
+					{% if blog.source == 'DecapCMS' %}
+						{% set imagePath = blog.coverImage.file.url + '.webp' %}
+					{% else %}
+						{% set imagePath = blog.coverImage.file.url + '?w=1536' %}
+					{% endif %}
+
 					{{ card(
-						blog.coverImage.file.url + '?w=1536',
+						imagePath,
 						blog.date | dateFormat,
 						blog.title,
 						'/blogs/' + blog.title | slugify,

--- a/src/project.njk
+++ b/src/project.njk
@@ -39,7 +39,7 @@ permalink: "projects/{{ project.title | slugify }}/"
                 {% else %}
                     {% set side = "right" %}
                 {% endif %}
-                <text-image-block side="{{ side }}" content="{{ component.content | markdownToHtml }}" image="{{ component.image | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}" imageAlt="{{ component.imageAlt }}" imageCaption="{{ component.imageCaption }}"></text-image-block>
+                <text-image-block side="{{ side }}" content="{{ component.content | markdownToHtml }}" image="{{ component.image | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}.webp" imageAlt="{{ component.imageAlt }}" imageCaption="{{ component.imageCaption }}"></text-image-block>
             {% elif component.type == "quote" %}
                 <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
             {% endif %}


### PR DESCRIPTION
## Context

The CMS build now optimises images. As part of this it also creates a webp alternative, which significantly reduces the file size in most cases, without compromising image quality.
 

## Changes proposed in this pull request

* Use webp where possible
* Ensure blog images from the old CMS don't use this


## Guidance to review

* Check the pages this affects still look okay


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
