### PR TITLE
Add site map to Knowledge Hub

### DIFF
--- a/src/_includes/knowledge-hub/base.njk
+++ b/src/_includes/knowledge-hub/base.njk
@@ -52,32 +52,38 @@
             <div class="govuk-width-container">
                 <div class="govuk-footer__meta">
                     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                    <svg
-                        aria-hidden="true"
-                        focusable="false"
-                        class="govuk-footer__licence-logo"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 483.2 195.7"
-                        height="17"
-                        width="41">
-                        <path
-                        fill="currentColor"
-                        d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-                    </svg>
-                    <span class="govuk-footer__licence-description">
-                        All content is available under the
-                        <a
-                        class="govuk-footer__link"
-                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                        rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-                    </span>
+                        <h2 class="govuk-visually-hidden">Support links</h2>
+                        <ul class="govuk-footer__inline-list">
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link" href="/knowledge-hub/site-map">Site map</a>
+                            </li>
+                        </ul>
+                        <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            class="govuk-footer__licence-logo"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 483.2 195.7"
+                            height="17"
+                            width="41">
+                            <path
+                                fill="currentColor"
+                                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                        </svg>
+                        <span class="govuk-footer__licence-description">
+                            All content is available under the
+                            <a
+                                class="govuk-footer__link"
+                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                        </span>
                     </div>
                     <div class="govuk-footer__meta-item">
-                    <a
+                        <a
                         class="govuk-footer__link govuk-footer__copyright-logo"
                         href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
                         © Crown copyright
-                    </a>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/knowledge-hub/site-map.njk
+++ b/src/knowledge-hub/site-map.njk
@@ -1,0 +1,35 @@
+---
+title: Site Map
+layout: knowledge-hub/base.njk
+templateEngineOverride: njk
+---
+
+
+{% from "../_includes/banner.njk" import banner %}
+{{ banner("Site Map") }}
+
+
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
+
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+      <li>
+        <a class="govuk-link" href="/knowledge-hub">Home page</a>
+      </li>
+      <li class="govuk-!-margin-top-2">
+        <a class="govuk-link" href="/knowledge-hub/use-cases">Use cases</a>
+        <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+          {% for useCase in knowledgeHubUseCases %}
+            <li class="govuk-!-margin-top-2">
+              <a class="govuk-link" href="/knowledge-hub/use-cases/{{ useCase.title | slugify }}">{{ useCase.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </li>
+      <li class="govuk-!-margin-top-2">
+        <a class="govuk-link" href="/knowledge-hub/guidance">Guidance</a>
+      </li>
+    </ul>
+
+  </div>
+</div>


### PR DESCRIPTION
## Context

We need a site map on the Knowledge Hub from an accessibility perspective.


## Changes proposed in this pull request

* Add a sitemap
* Add a link to this in the footer


## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
