### PR TITLE
Add right hand column to product pages

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -84,6 +84,14 @@
   }
 }
 
+.fact-panel{
+  background: linear-gradient(#fafafa 0%, #efefef 100%);
+  padding: 1em;
+  margin: 2em 0;
+}
+.fact-panel p{
+  margin-bottom: 1em;
+}
 
 
 /* TO MOVE TO I.AI DESIGN SYSTEM */

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -84,14 +84,6 @@
   }
 }
 
-.fact-panel{
-  background: linear-gradient(#fafafa 0%, #efefef 100%);
-  padding: 1em;
-  margin: 2em 0;
-}
-.fact-panel p{
-  margin-bottom: 1em;
-}
 
 
 /* TO MOVE TO I.AI DESIGN SYSTEM */

--- a/src/project.njk
+++ b/src/project.njk
@@ -21,72 +21,39 @@ permalink: "projects/{{ project.title | slugify }}/"
 </div>
 
 <div class="govuk-width-container">
-    <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
+  <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
 
-        
-
-                <div class="iai-blog-content govuk-body">
-                {% for component in project.components %}
-                    {% if component.type == "bodyText" %}
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
-                        {{ component.content | markdownToHtml(true) | safe }}
-                        </div>
-                    </div>
-                    {% elif component.type == "video" %}
-
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
-                        {{ video({
-                            classes: "iai-promo-video",
-                            source: component.source,
-                            audioDescription: component.audioDescription
-                        }) }}
-                        </div>
-                    </div>
-                    {% elif component.type == "doubleColumn" %}
-
-
-                        {% if component.order == "Text (left) - Image (right)" %}
-                            {% set side = "left" %}
-                        {% else %}
-                            {% set side = "right" %}
-                        {% endif %}
-
-                        {% if '.svg' in component.image %}
-                            {% set imgPath = component.image %}
-                        {% else %}
-                            {% set imgPath = component.image + '.webp' %}
-                        {% endif %}
-
-
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
-                            {{ component.content | markdownToHtml(true) | safe }}
-
-                        </div>
-                        <div class="govuk-grid-column-one-third">
-                            <figure>
-                           <img class="block mt-4 w-full lg:!mt-0" src='{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}' alt="{{ component.imageAlt }}"> 
-                           <figcaption>{{ component.imageCaption }}</figcaption> 
-                       </figure>
-                        </div>
-                    </div>
-
-                    {% elif component.type == "quote" %}
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
-                            </div>
-                        </div>
-                    {% endif %}
-                {% endfor %}
-                </div>
-
-
-
+    <div class="iai-blog-content govuk-body">
+        {% for component in project.components %}
+            {% if component.type == "bodyText" %}
+                {{ component.content | markdownToHtml(true) | safe }}
+            {% elif component.type == "video" %}
+                {{ video({
+                    classes: "iai-promo-video",
+                    source: component.source,
+                    audioDescription: component.audioDescription
+                }) }}
+            {% elif component.type == "doubleColumn" %}
+                {% if component.order == "Text (left) - Image (right)" %}
+                    {% set side = "left" %}
+                {% else %}
+                    {% set side = "right" %}
+                {% endif %}
+                {% if '.svg' in component.image %}
+                    {% set imgPath = component.image %}
+                {% else %}
+                    {% set imgPath = component.image + '.webp' %}
+                {% endif %}
+                <text-image-block side="{{ side }}" content="{{ component.content | markdownToHtml(true) }}" image="{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}" imageAlt="{{ component.imageAlt }}" imageCaption="{{ component.imageCaption }}"></text-image-block>
+            {% elif component.type == "quote" %}
+                <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
+            {% endif %}
+        {% endfor %}
     </div>
+
+  </div>
 </div>
+
 {# CMS Preview #}
 {% if project.title === "Preview" %}
     <script src="/js/add-govuk-classes.js"></script>

--- a/src/project.njk
+++ b/src/project.njk
@@ -24,6 +24,9 @@ permalink: "projects/{{ project.title | slugify }}/"
   <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
 
     <div class="iai-blog-content govuk-body">
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
         {% for component in project.components %}
             {% if component.type == "bodyText" %}
                 {{ component.content | markdownToHtml(true) | safe }}
@@ -34,21 +37,25 @@ permalink: "projects/{{ project.title | slugify }}/"
                     audioDescription: component.audioDescription
                 }) }}
             {% elif component.type == "doubleColumn" %}
-                {% if component.order == "Text (left) - Image (right)" %}
-                    {% set side = "left" %}
-                {% else %}
-                    {% set side = "right" %}
-                {% endif %}
                 {% if '.svg' in component.image %}
                     {% set imgPath = component.image %}
                 {% else %}
                     {% set imgPath = component.image + '.webp' %}
                 {% endif %}
-                <text-image-block side="{{ side }}" content="{{ component.content | markdownToHtml(true) }}" image="{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}" imageAlt="{{ component.imageAlt }}" imageCaption="{{ component.imageCaption }}"></text-image-block>
+
+                {{ component.content | markdownToHtml(true) | safe }}
+
+                 <figure>
+                   <img class="block mt-4 w-full lg:!mt-0" src='{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}' alt="{{ component.imageAlt }}"> 
+                   <figcaption>{{ component.imageCaption }}</figcaption> 
+                </figure>
             {% elif component.type == "quote" %}
                 <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
             {% endif %}
         {% endfor %}
+
+    </div>
+</div>
     </div>
 
   </div>

--- a/src/project.njk
+++ b/src/project.njk
@@ -21,39 +21,72 @@ permalink: "projects/{{ project.title | slugify }}/"
 </div>
 
 <div class="govuk-width-container">
-  <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
+    <div class="govuk-main-wrapper govuk-!-padding-bottom-0">
 
-    <div class="iai-blog-content govuk-body">
-        {% for component in project.components %}
-            {% if component.type == "bodyText" %}
-                {{ component.content | markdownToHtml(true) | safe }}
-            {% elif component.type == "video" %}
-                {{ video({
-                    classes: "iai-promo-video",
-                    source: component.source,
-                    audioDescription: component.audioDescription
-                }) }}
-            {% elif component.type == "doubleColumn" %}
-                {% if component.order == "Text (left) - Image (right)" %}
-                    {% set side = "left" %}
-                {% else %}
-                    {% set side = "right" %}
-                {% endif %}
-                {% if '.svg' in component.image %}
-                    {% set imgPath = component.image %}
-                {% else %}
-                    {% set imgPath = component.image + '.webp' %}
-                {% endif %}
-                <text-image-block side="{{ side }}" content="{{ component.content | markdownToHtml(true) }}" image="{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}" imageAlt="{{ component.imageAlt }}" imageCaption="{{ component.imageCaption }}"></text-image-block>
-            {% elif component.type == "quote" %}
-                <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
-            {% endif %}
-        {% endfor %}
+        
+
+                <div class="iai-blog-content govuk-body">
+                {% for component in project.components %}
+                    {% if component.type == "bodyText" %}
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-two-thirds">
+                        {{ component.content | markdownToHtml(true) | safe }}
+                        </div>
+                    </div>
+                    {% elif component.type == "video" %}
+
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-two-thirds">
+                        {{ video({
+                            classes: "iai-promo-video",
+                            source: component.source,
+                            audioDescription: component.audioDescription
+                        }) }}
+                        </div>
+                    </div>
+                    {% elif component.type == "doubleColumn" %}
+
+
+                        {% if component.order == "Text (left) - Image (right)" %}
+                            {% set side = "left" %}
+                        {% else %}
+                            {% set side = "right" %}
+                        {% endif %}
+
+                        {% if '.svg' in component.image %}
+                            {% set imgPath = component.image %}
+                        {% else %}
+                            {% set imgPath = component.image + '.webp' %}
+                        {% endif %}
+
+
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-two-thirds">
+                            {{ component.content | markdownToHtml(true) | safe }}
+
+                        </div>
+                        <div class="govuk-grid-column-one-third">
+                            <figure>
+                           <img class="block mt-4 w-full lg:!mt-0" src='{{ imgPath | replace("/images/uploads/", "https://i-dot-ai-cms.netlify.app/assets/") }}' alt="{{ component.imageAlt }}"> 
+                           <figcaption>{{ component.imageCaption }}</figcaption> 
+                       </figure>
+                        </div>
+                    </div>
+
+                    {% elif component.type == "quote" %}
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <project-quote quote="{{ component.quote }}" by="{{ component.author }}" link="{{ component.link | trim }}"></project-quote>
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+                </div>
+
+
+
     </div>
-
-  </div>
 </div>
-
 {# CMS Preview #}
 {% if project.title === "Preview" %}
     <script src="/js/add-govuk-classes.js"></script>


### PR DESCRIPTION
## Context

Adds a right hand column to product pages, so that:

- the line length of the content is more readable
- we can add a 'Key facts' panel to the column later

## Guidance to review

The 'doubleColumn' component now ignores the left/right setting and displays all images stacked below the text. Can we update the CMS accordingly, so that this component is called 'Text and image' and has no settings?.

Alternatively, is it possible to insert stacked images using the bodytext component?

## Things to check

- [ ] Styling has not broken
- [ ] Content changes have been reviewed and approved
- [ ] No sensitive information about the team or our upcoming work has been included
